### PR TITLE
Handle null and undefined values when generating styles.

### DIFF
--- a/addon/mixins/styled-component.js
+++ b/addon/mixins/styled-component.js
@@ -65,7 +65,11 @@ export default Mixin.create({
   },
 
   _buildStyle(property, value) {
-    return this._fixStyles(property, value).join(':');
+    if (typeof value === 'undefined' || value === null ) {
+      return null;
+    } else {
+      return this._fixStyles(property, value).join(':');
+    }
   },
 
   _buildStyles() {
@@ -74,12 +78,14 @@ export default Mixin.create({
       this.styleBindings.forEach((binding) => {
         let [key, property] = binding.split(':');
         if(!property) { property = key; }
-        styles.push(this._buildStyle(property, this.get(key)));
+        let style = this._buildStyle(property, this.get(key));
+        if (style !== null ) styles.push(style);
       });
     }
     if(this.styles) {
       Object.keys(this.styles).forEach((key) => {
-        styles.push(this._buildStyle(key, this.get('styles.'+key)));
+        let style = this._buildStyle(key, this.get('styles.'+key))
+        if (style !== null) styles.push(style);
       });
     }
     // console.log('styles', styles);

--- a/addon/mixins/styled-component.js
+++ b/addon/mixins/styled-component.js
@@ -84,7 +84,7 @@ export default Mixin.create({
     }
     if(this.styles) {
       Object.keys(this.styles).forEach((key) => {
-        let style = this._buildStyle(key, this.get('styles.'+key))
+        let style = this._buildStyle(key, this.get('styles.'+key));
         if (style !== null) styles.push(style);
       });
     }

--- a/tests/unit/mixins/styled-component-test.js
+++ b/tests/unit/mixins/styled-component-test.js
@@ -114,4 +114,19 @@ module('Unit | Mixin | styled component', function() {
 
     assert.equal(subject.get('style').toHTML(), 'width:50px;top:0px;left:0px;z-index:99');
   });
+
+  test('it does not add a style if the property value is null or undefined', function(assert) {
+    let StyledComponentObject = EmberObject.extend(StyledComponentMixin, {
+      styleBindings: ['theWidth:width', 'theHeight:height', 'backgroundColor'], // eslint-disable-line
+      styles: { // eslint-disable-line
+        marginTop: null
+      },
+      theWidth: 50,
+      theHeight: null
+      // backgroundColor is also intentionally left undefined
+    });
+    let subject = StyledComponentObject.create();
+
+    assert.equal(subject.get('style').toHTML(), 'width:50px');
+  });
 });


### PR DESCRIPTION
This will skip generating styles for properties that are null or
undefined. Previously it would generate styles like:

- `width:nullpx`
- `width:`

Fixes #2 

Also tested in a real application this morning.

👍 